### PR TITLE
Implement R3 (persistent storage) and R4 (sort/filter)

### DIFF
--- a/leftover_legends/lib/providers/item_provider.dart
+++ b/leftover_legends/lib/providers/item_provider.dart
@@ -6,13 +6,13 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/item.dart';
 import '../repositories/item_repository.dart';
-import '../repositories/mock_item_repository.dart';
-// import '../repositories/local_item_repository.dart'; // ← uncomment when ready
+// import '../repositories/mock_item_repository.dart';
+import '../repositories/local_item_repository.dart'; // ← real storage
 
 // The repository provider — swap implementation here
 final repositoryProvider = Provider<ItemRepository>((ref) {
-  return MockItemRepository();
-  // return LocalItemRepository(); // ← switch to this for real storage
+  // return MockItemRepository();
+  return LocalItemRepository(); // ← real localStorage persistence
 });
 
 // The main items state notifier
@@ -44,6 +44,37 @@ class ItemNotifier extends AsyncNotifier<List<FridgeItem>> {
 // The provider screens watch
 final itemsProvider =
     AsyncNotifierProvider<ItemNotifier, List<FridgeItem>>(ItemNotifier.new);
+
+// Filter mode enum
+enum FilterMode { all, expiring, fresh }
+
+// Filter state provider
+final filterProvider = StateProvider<FilterMode>((ref) => FilterMode.all);
+
+// Filtered + sorted items provider
+final filteredItemsProvider = Provider<AsyncValue<List<FridgeItem>>>((ref) {
+  final mode = ref.watch(filterProvider);
+  return ref.watch(itemsProvider).whenData((items) {
+    // Sort by expiry date, soonest first
+    final sorted = [...items]
+      ..sort((a, b) => a.expiryDate.compareTo(b.expiryDate));
+
+    switch (mode) {
+      case FilterMode.all:
+        return sorted;
+      case FilterMode.expiring:
+        return sorted
+            .where((i) =>
+                i.status == ExpiryStatus.danger ||
+                i.status == ExpiryStatus.warn)
+            .toList();
+      case FilterMode.fresh:
+        return sorted
+            .where((i) => i.status == ExpiryStatus.good)
+            .toList();
+    }
+  });
+});
 
 // Convenience provider: items filtered by expiry status
 // Usage: ref.watch(expiringItemsProvider) in any screen

--- a/leftover_legends/lib/screens/fridge_screen.dart
+++ b/leftover_legends/lib/screens/fridge_screen.dart
@@ -1,6 +1,5 @@
 // lib/screens/fridge_screen.dart
-// R3 — Main fridge list. Engineer 1 owns this file.
-// Reads from itemsProvider — works with mock data on day 1.
+// R3/R4 — Main fridge list with filter switching.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -14,195 +13,81 @@ class FridgeScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final itemsAsync = ref.watch(itemsProvider);
+    final filteredAsync = ref.watch(filteredItemsProvider);
+    final currentFilter = ref.watch(filterProvider);
 
     return Scaffold(
-      backgroundColor: const Color(0xFF1A1F1C),
       appBar: AppBar(
-        backgroundColor: const Color(0xFF1A1F1C),
-        title: const Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              'Good morning 🌿',
-              style: TextStyle(
-                color: Color(0xFF8A9E90),
-                fontSize: 11,
-                fontWeight: FontWeight.w700,
-              ),
-            ),
-            Text(
-              'My Fridge',
-              style: TextStyle(
-                color: Color(0xFFF5EFE0),
-                fontSize: 22,
-                fontWeight: FontWeight.w900,
-              ),
-            ),
-          ],
-        ),
-        actions: [
-          // Streak badge
-          Container(
-            margin: const EdgeInsets.only(right: 16),
-            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
-            decoration: BoxDecoration(
-              color: const Color(0xFF1A1F1C),
-              border: Border.all(color: const Color(0xFFE8A83840)),
-              borderRadius: BorderRadius.circular(20),
-            ),
-            child: const Row(
-              children: [
-                Text('🔥', style: TextStyle(fontSize: 14)),
-                SizedBox(width: 4),
-                Text(
-                  '12',
-                  style: TextStyle(
-                    color: Color(0xFFE8A838),
-                    fontWeight: FontWeight.w900,
-                    fontSize: 12,
-                  ),
-                ),
+        title: const Text('My Fridge'),
+      ),
+      body: Column(
+        children: [
+          // Filter switcher
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+            child: SegmentedButton<FilterMode>(
+              segments: const [
+                ButtonSegment(value: FilterMode.all, label: Text('All')),
+                ButtonSegment(
+                    value: FilterMode.expiring, label: Text('Expiring')),
+                ButtonSegment(value: FilterMode.fresh, label: Text('Fresh')),
               ],
+              selected: {currentFilter},
+              onSelectionChanged: (selected) {
+                ref.read(filterProvider.notifier).state = selected.first;
+              },
+            ),
+          ),
+
+          // Item list
+          Expanded(
+            child: filteredAsync.when(
+              loading: () =>
+                  const Center(child: CircularProgressIndicator()),
+              error: (e, _) => Center(child: Text('Error: $e')),
+              data: (items) {
+                if (items.isEmpty) {
+                  return const Center(child: Text('No items here.'));
+                }
+                return ListView(
+                  padding: const EdgeInsets.fromLTRB(16, 4, 16, 80),
+                  children: [
+                    // Item count
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 8),
+                      child: Text('${items.length} item${items.length == 1 ? '' : 's'}'),
+                    ),
+
+                    // Item cards
+                    ...items.map((item) => Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: ItemCard(
+                            item: item,
+                            onDelete: () => ref
+                                .read(itemsProvider.notifier)
+                                .deleteItem(item.id),
+                          ),
+                        )),
+                  ],
+                );
+              },
             ),
           ),
         ],
-      ),
-      body: itemsAsync.when(
-        loading: () => const Center(
-          child: CircularProgressIndicator(color: Color(0xFF5C9E6E)),
-        ),
-        error: (e, _) => Center(
-          child: Text('Error: $e',
-              style: const TextStyle(color: Color(0xFFF5EFE0))),
-        ),
-        data: (items) => items.isEmpty
-            ? _buildEmptyState()
-            : _buildList(context, ref, items),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => context.push('/add'),
-        backgroundColor: const Color(0xFF5C9E6E),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(18),
-        ),
-        child: const Icon(Icons.add, size: 28),
+        child: const Icon(Icons.add),
       ),
-      bottomNavigationBar: _buildBottomNav(context),
-    );
-  }
-
-  Widget _buildList(
-      BuildContext context, WidgetRef ref, List<FridgeItem> items) {
-    return ListView(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 80),
-      children: [
-        // Expiry alert banner (if any danger items)
-        if (items.any((i) => i.status == ExpiryStatus.danger))
-          _buildAlertBanner(items.firstWhere(
-              (i) => i.status == ExpiryStatus.danger)),
-        const SizedBox(height: 8),
-
-        // Section header
-        Padding(
-          padding: const EdgeInsets.symmetric(vertical: 8),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              const Text(
-                'Fridge Contents',
-                style: TextStyle(
-                  color: Color(0xFFD9CEB2),
-                  fontWeight: FontWeight.w800,
-                  fontSize: 11,
-                  letterSpacing: 0.4,
-                ),
-              ),
-              Text(
-                '${items.length} items',
-                style: const TextStyle(
-                  color: Color(0xFF8A9E90),
-                  fontSize: 10,
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-            ],
-          ),
-        ),
-
-        // Item cards
-        ...items.map((item) => Padding(
-              padding: const EdgeInsets.only(bottom: 8),
-              child: ItemCard(
-                item: item,
-                onDelete: () =>
-                    ref.read(itemsProvider.notifier).deleteItem(item.id),
-              ),
-            )),
-      ],
-    );
-  }
-
-  Widget _buildAlertBanner(FridgeItem item) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 9),
-      decoration: BoxDecoration(
-        color: const Color(0xFF1A1F1C),
-        border: Border.all(color: const Color(0xFFE8A83840)),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Row(
-        children: [
-          const Text('⏰', style: TextStyle(fontSize: 16)),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              '${item.name} expires soon! · Tap to take action',
-              style: const TextStyle(
-                color: Color(0xFFE8A838),
-                fontSize: 11,
-                fontWeight: FontWeight.w800,
-              ),
-            ),
-          ),
-          const Text('›',
-              style: TextStyle(color: Color(0xFFE8A83888), fontSize: 16)),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: 0,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+          BottomNavigationBarItem(
+              icon: Icon(Icons.explore), label: 'Discover'),
+          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
         ],
       ),
-    );
-  }
-
-  Widget _buildEmptyState() {
-    return const Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Text('🎉', style: TextStyle(fontSize: 48)),
-          SizedBox(height: 12),
-          Text(
-            'Your fridge is clear!',
-            style: TextStyle(
-              color: Color(0xFF8A9E90),
-              fontSize: 16,
-              fontWeight: FontWeight.w700,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildBottomNav(BuildContext context) {
-    return BottomNavigationBar(
-      backgroundColor: const Color(0xFF242C27),
-      selectedItemColor: const Color(0xFF7FAF8A),
-      unselectedItemColor: const Color(0xFF8A9E90),
-      currentIndex: 0,
-      items: const [
-        BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
-        BottomNavigationBarItem(icon: Icon(Icons.explore), label: 'Discover'),
-        BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
-      ],
     );
   }
 }


### PR DESCRIPTION
R3 — Activate LocalItemRepository
- Switch from MockItemRepository to LocalItemRepository
- Items now persist in browser localStorage via shared_preferences
- Data survives page refreshes

R4 — Add sort/filter logic
- Add FilterMode enum (all, expiring, fresh)
- Add filterProvider (StateProvider) for filter state
- Add filteredItemsProvider that derives filtered list from itemsProvider + filterProvider
  - all: all items sorted by expiry date (soonest first)
  - expiring: items with danger or warn status (daysLeft ≤ 4)
  - fresh: items with good status (daysLeft > 4)
- Strip decorative UI from fridge_screen.dart
- Add SegmentedButton for filter switching
- Use filteredItemsProvider instead of itemsProvider in list